### PR TITLE
Fix bidirectional eventing

### DIFF
--- a/Common/JsonRpcHelper.cs
+++ b/Common/JsonRpcHelper.cs
@@ -12,7 +12,8 @@ namespace Common
 {
     public static class JsonRpcHelper
     {
-        public static async Task MarshalRemoteServerObjectAsync(IPAddress address, int port, IJsonRpc agvInterface)
+        public static async Task MarshalRemoteServerObjectAsync<T>(IPAddress address, int port, T agvInterface)
+            where T : IJsonRpc
         {
             int clientId = 1;
             TcpListener tcpListener = new TcpListener(address, port);
@@ -28,9 +29,12 @@ namespace Common
             }
         }
 
-        static async Task TcpResponseAsync(NetworkStream stream, int clientId, IJsonRpc agvInterface)
+        static async Task TcpResponseAsync<T>(NetworkStream stream, int clientId, T agvInterface)
+            where T : IJsonRpc
         {
-            var jsonRpc = JsonRpc.Attach(stream, agvInterface);
+            var jsonRpc = new JsonRpc(stream);
+            jsonRpc.AddLocalRpcTarget<T>(agvInterface, null);
+            jsonRpc.StartListening();
             await jsonRpc.Completion;
             Console.WriteLine($"Client #{clientId} Disconnect");
             jsonRpc.Dispose();

--- a/JsonRpcClient/Exe2Obj.cs
+++ b/JsonRpcClient/Exe2Obj.cs
@@ -24,7 +24,7 @@ namespace JsonRpcClient
         {
             IPAddress address = IPAddress.Parse("127.0.0.1");
             int port = 6100;
-            _ = JsonRpcHelper.MarshalRemoteServerObjectAsync(address, port, this);
+            _ = JsonRpcHelper.MarshalRemoteServerObjectAsync<IExe2>(address, port, this);
         }
 
         public void Exe2Received(Exe2Args args)

--- a/JsonRpc_Server/Exe1Obj.cs
+++ b/JsonRpc_Server/Exe1Obj.cs
@@ -24,7 +24,7 @@ namespace JsonRpc_Server
         {
             IPAddress address = IPAddress.Parse("127.0.0.1");
             int port = 6000;
-            _ = JsonRpcHelper.MarshalRemoteServerObjectAsync(address, port, this);
+            _ = JsonRpcHelper.MarshalRemoteServerObjectAsync<IExe1>(address, port, this);
         }
 
 


### PR DESCRIPTION
The problem was that your RPC target objects included events that StreamJsonRpc didn't support. But these events had nothing to do with your RPC interface, so it was safe to ignore them. We tell StreamJsonRpc exactly which members to ignore and consider by explicitly passing it your RPC interface type instead of the concrete class type. This gets your demo working.